### PR TITLE
Updated dependencies & minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.idea/*
 target/*
 docs/*
 out/*
 out.jar
 testing/*
+*.iml

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ field and method that was referenced and used in the original jar, as
 well as a supertype that respects every type constraint that was found
 (e.g., if phantom class B was used in a place where known class A was
 expected, and a [widening reference
-conversion](http://docs.oracle.com/javase/specs/jls/se7/html/jls-5.html#jls-5.1.5)
+conversion](http://docs.oracle.com/javase/specs/jls/se14/html/jls-5.html#jls-5.1.5)
 took place, then we must conclude that class A is a supertype of B).
 
 You can read more about the underlying problem of class hierarchy
@@ -30,7 +30,7 @@ your `pom.xml`:
 <dependency>
   <groupId>org.clyze</groupId>
   <artifactId>jphantom</artifactId>
-  <version>1.2</version>
+  <version>1.3</version>
 </dependency>
 ```
 
@@ -38,7 +38,7 @@ To add a dependency using Gradle:
 
 ```
 dependencies {
-  compile 'org.clyze:jphantom:1.2'
+  compile 'org.clyze:jphantom:1.3'
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.clyze</groupId>
   <artifactId>jphantom</artifactId>
-  <version>1.2</version>
+  <version>1.3</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
@@ -35,34 +35,54 @@
   <!-- Dependencies -->
   <dependencies>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>${asm.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-debug-all</artifactId>
-      <version>5.0.3</version>
+      <artifactId>asm-tree</artifactId>
+      <version>${asm.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <version>${asm.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+      <version>${asm.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-analysis</artifactId>
+      <version>${asm.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>29.0-jre</version>
     </dependency>
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
-      <version>2.0.23</version>
+      <version>2.33</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.10</version>
+      <version>1.2.3</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.0.10</version>
+      <version>1.2.3</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.3</version>
+      <version>1.7.30</version>
     </dependency>
     <dependency>
       <groupId>net.sf.jgrapht</groupId>
@@ -72,27 +92,37 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.1</version>
+      <version>3.11</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>annotations</artifactId>
-      <version>2.0.1</version>
+      <version>3.0.1</version>
     </dependency>
   </dependencies>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <asm.version>8.0.1</asm.version>
   </properties>
 
   <build>
     <plugins>
+      <!-- Maven version enforcement -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <generateBackupPoms>false</generateBackupPoms>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.9.0</version>
       </plugin>
 
       <plugin>
@@ -113,7 +143,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.3</version>
+        <version>1.6.8</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>
@@ -126,7 +156,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -140,7 +170,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -150,7 +180,7 @@
           </execution>
         </executions>
         <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <doclint>none</doclint>
         </configuration>
       </plugin>
 
@@ -158,7 +188,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.2.0</version>
         <configuration>
           <archive>
             <manifest>
@@ -172,6 +202,7 @@
       <!-- Building fat JAR -->
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifest>
@@ -195,10 +226,10 @@
       <!-- Compilation and Debug Information -->
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <debug>true</debug>
           <debuglevel>lines,vars,source</debuglevel>
           <compilerArgs>
@@ -215,7 +246,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.5</version>
+        <version>3.0.5</version>
       </plugin>
     </plugins>
   </reporting>

--- a/src/main/java/org/clyze/jphantom/ClassMembers.java
+++ b/src/main/java/org/clyze/jphantom/ClassMembers.java
@@ -225,11 +225,11 @@ public class ClassMembers implements Opcodes, Types
         }
 
         public Feeder(ClassVisitor cv) {
-            this(ASM5, cv);
+            this(Options.ASM_VER, cv);
         }
 
         public Feeder() {
-            this(ASM5);
+            this(Options.ASM_VER);
         }
 
         @Override
@@ -294,15 +294,11 @@ public class ClassMembers implements Opcodes, Types
                 if (!entry.getName().endsWith(".class"))
                     continue;
 
-                InputStream stream = file.getInputStream(entry);
-
-                try {
+                try (InputStream stream = file.getInputStream(entry)) {
                     ClassReader reader = new ClassReader(stream);
 
                     // Add type to hierarchy
                     reader.accept(repo.new Feeder(), 0);
-                } finally {
-                    stream.close();
                 }
             }
             return repo;

--- a/src/main/java/org/clyze/jphantom/Driver.java
+++ b/src/main/java/org/clyze/jphantom/Driver.java
@@ -86,7 +86,6 @@ public class Driver implements Types
             jin.close();
         }
 
-        hierarchy = new UnmodifiableClassHierarchy(hierarchy);
         phantom = new JPhantom(nodes, hierarchy, members);
     }
     

--- a/src/main/java/org/clyze/jphantom/Driver.java
+++ b/src/main/java/org/clyze/jphantom/Driver.java
@@ -1,13 +1,11 @@
 package org.clyze.jphantom;
 
 import org.kohsuke.args4j.*;
-import org.kohsuke.args4j.spi.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
-import java.nio.*;
 import java.nio.file.*;
 import java.nio.file.attribute.*;
 import java.util.*;

--- a/src/main/java/org/clyze/jphantom/JPhantom.java
+++ b/src/main/java/org/clyze/jphantom/JPhantom.java
@@ -1,0 +1,195 @@
+package org.clyze.jphantom;
+
+import org.clyze.jphantom.access.ClassAccessStateMachine;
+import org.clyze.jphantom.access.FieldAccessStateMachine;
+import org.clyze.jphantom.access.MethodAccessStateMachine;
+import org.clyze.jphantom.adapters.*;
+import org.clyze.jphantom.constraints.Constraint;
+import org.clyze.jphantom.constraints.extractors.TypeConstraintExtractor;
+import org.clyze.jphantom.constraints.solvers.*;
+import org.clyze.jphantom.hier.ClassHierarchies;
+import org.clyze.jphantom.hier.ClassHierarchy;
+import org.clyze.jphantom.hier.PrintableClassHierarchy;
+import org.clyze.jphantom.methods.MethodDeclarations;
+import org.clyze.jphantom.methods.MethodSignature;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.signature.SignatureReader;
+import org.objectweb.asm.signature.SignatureVisitor;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+public class JPhantom {
+	protected final static Logger logger =
+			LoggerFactory.getLogger(Driver.class);
+	private final Phantoms phantoms = Phantoms.V();
+	private final Map<Type, ClassNode> nodes;
+	private final ClassHierarchy hierarchy;
+	private final ClassMembers members;
+	private Map<Type, byte[]> generated;
+
+	public JPhantom(Map<Type, ClassNode> nodes, ClassHierarchy hierarchy, ClassMembers members) {
+		this.nodes = nodes;
+		this.hierarchy = hierarchy;
+		this.members = members;
+
+		// Resolve all phantom supertypes so far
+
+		final SignatureVisitor visitor = new PhantomAdder(
+				hierarchy, members, phantoms);
+
+		for (Type unknown : ClassHierarchies.unknownTypes(hierarchy))
+			new SignatureReader("" + unknown).acceptType(visitor);
+
+		// Sanity check
+
+		for (Type unknown : ClassHierarchies.unknownTypes(hierarchy))
+			assert phantoms.contains(unknown);
+	}
+
+	public void run() throws IOException
+	{
+		// Analyze
+
+		TypeConstraintSolver solver =
+				new ConstraintStoringSolver(
+						new BasicSolver.Builder().hierarchy(hierarchy).build());
+
+		// Prune unrelated types before feeding them to the solver
+		solver = new PruningSolver(solver);
+
+		TypeConstraintExtractor extractor = new TypeConstraintExtractor(solver);
+
+		for (ClassNode node : nodes.values()) {
+			try {
+				extractor.visit(node);
+			} catch (AnalyzerException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		// Additional constraints
+		for (Constraint c : FieldAccessStateMachine.v().getConstraints())
+			c.accept(solver);
+		for (Constraint c : MethodAccessStateMachine.v().getConstraints())
+			c.accept(solver);
+		for (Constraint c : ClassAccessStateMachine.v().getConstraints())
+			c.accept(solver);
+
+		for (Constraint c : solver.getConstraints())
+			logger.info("Constraint: {}", c);
+
+		// Solve constraints
+		ClassHierarchy solution;
+
+		try {
+			solution = solver.solve().getSolution();
+		} catch (Solver.UnsatisfiableStateException exc) {
+			throw new RuntimeException(exc);
+		}
+
+		logger.info("Found Solution: \n\n{}", new PrintableClassHierarchy(solution));
+
+		// Add supertypes
+		addSupertypes(solution);
+
+		// Generate files
+		generated = phantoms.generateClasses();
+
+		// Load required class methods of the types that comprise our solution
+		fillLookupTable(solution);
+
+		// Add missing methods
+		addMissingMethods(
+				generated, solution, new MethodDeclarations(solution, phantoms.getLookupTable()));
+	}
+
+	private void fillLookupTable(ClassHierarchy solution) throws IOException
+	{
+		for (Type t : solution)
+		{
+			// Phantom Type
+			if (phantoms.contains(t))
+				continue;
+
+			ClassVisitor visitor = phantoms.getLookupTable().new CachingAdapter();
+
+			// Input Type
+			if (nodes.containsKey(t)) {
+				nodes.get(t).accept(visitor);
+				continue;
+			}
+
+			// Library Type
+			new ClassReader(t.getInternalName()).accept(visitor, 0);
+		}
+	}
+
+	private void addSupertypes(ClassHierarchy solution)
+	{
+		for (Type p : solution)
+		{
+			if (hierarchy.contains(p))
+				continue;
+
+			assert phantoms.contains(p) : p;
+
+			// Get top class visitor
+			Transformer tr = phantoms.getTransformer(p);
+
+			assert tr.top != null;
+
+			// Chain a superclass / interface adapter
+
+			tr.top = solution.isInterface(p) ?
+					new InterfaceTransformer(tr.top) :
+					new SuperclassAdapter(tr.top, solution.getSuperclass(p));
+
+			// Chain an interface adder
+
+			tr.top = new InterfaceAdder(tr.top, solution.getInterfaces(p));
+		}
+	}
+
+	private void addMissingMethods(Map<Type, byte[]> generated, ClassHierarchy solution, MethodDeclarations declarations) {
+		for (Type p : phantoms)
+		{
+			Set<MethodSignature> pending = declarations.getPending(p);
+
+			if (pending == null) {
+				assert !solution.contains(p);
+				continue;
+			}
+
+			if (pending.isEmpty())
+				continue;
+
+			for (MethodSignature m : pending)
+			{
+				logger.debug("Adding method {} to \"{}\"", m, p.getClassName());
+
+				// Chain a method-adder adapter
+
+				ClassWriter cw = new ClassWriter(0);
+				ClassVisitor cv = new MethodAdder(cw, m);
+
+				ClassReader cr = new ClassReader(generated.get(p));
+				cr.accept(cv, 0);
+
+				generated.put(p, cw.toByteArray());
+			}
+		}
+	}
+
+	public Map<Type, byte[]> getGenerated() {
+		return generated;
+	}
+}

--- a/src/main/java/org/clyze/jphantom/JPhantom.java
+++ b/src/main/java/org/clyze/jphantom/JPhantom.java
@@ -108,8 +108,7 @@ public class JPhantom {
 		fillLookupTable(solution);
 
 		// Add missing methods
-		addMissingMethods(
-				generated, solution, new MethodDeclarations(solution, phantoms.getLookupTable()));
+		addMissingMethods(solution, new MethodDeclarations(solution, phantoms.getLookupTable()));
 	}
 
 	private void fillLookupTable(ClassHierarchy solution) throws IOException
@@ -159,7 +158,7 @@ public class JPhantom {
 		}
 	}
 
-	private void addMissingMethods(Map<Type, byte[]> generated, ClassHierarchy solution, MethodDeclarations declarations) {
+	private void addMissingMethods(ClassHierarchy solution, MethodDeclarations declarations) {
 		for (Type p : phantoms)
 		{
 			Set<MethodSignature> pending = declarations.getPending(p);

--- a/src/main/java/org/clyze/jphantom/JPhantom.java
+++ b/src/main/java/org/clyze/jphantom/JPhantom.java
@@ -10,6 +10,7 @@ import org.clyze.jphantom.constraints.solvers.*;
 import org.clyze.jphantom.hier.ClassHierarchies;
 import org.clyze.jphantom.hier.ClassHierarchy;
 import org.clyze.jphantom.hier.PrintableClassHierarchy;
+import org.clyze.jphantom.hier.UnmodifiableClassHierarchy;
 import org.clyze.jphantom.methods.MethodDeclarations;
 import org.clyze.jphantom.methods.MethodSignature;
 import org.objectweb.asm.ClassReader;
@@ -38,7 +39,7 @@ public class JPhantom {
 
     public JPhantom(Map<Type, ClassNode> nodes, ClassHierarchy hierarchy, ClassMembers members) {
         this.nodes = nodes;
-        this.hierarchy = hierarchy;
+        this.hierarchy = new UnmodifiableClassHierarchy(hierarchy);
         this.members = members;
 
         // Resolve all phantom supertypes so far

--- a/src/main/java/org/clyze/jphantom/Options.java
+++ b/src/main/java/org/clyze/jphantom/Options.java
@@ -1,20 +1,20 @@
 package org.clyze.jphantom;
 
-import java.util.*;
 import java.nio.file.*;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import org.objectweb.asm.Opcodes;
 import org.slf4j.LoggerFactory;
 import org.kohsuke.args4j.*;
 import org.kohsuke.args4j.spi.*;
 import static ch.qos.logback.classic.Level.*;
 
 public class Options {
-
     private final static FileSystem fs = FileSystems.getDefault();
     private final static Logger logger = (Logger) LoggerFactory.getLogger("jphantom");
     private final static Level[] levels = {OFF, ERROR, WARN, INFO, DEBUG, TRACE, ALL};
     private final static Options INSTANCE = new Options();
+    public static final int ASM_VER = Opcodes.ASM8;
 
     public static Options V() {
         return INSTANCE;

--- a/src/main/java/org/clyze/jphantom/Phantoms.java
+++ b/src/main/java/org/clyze/jphantom/Phantoms.java
@@ -46,34 +46,17 @@ public class Phantoms extends ForwardingSet<Type>
         return mtable;
     }
 
-    public List<File> generateFiles(File outDir) throws IOException
+    public Map<Type, byte[]> generateClasses() throws IOException
     {
-        List<File> files = new LinkedList<>();
+        Map<Type, byte[]> map = new HashMap<>();
 
         for (Map.Entry<Type,Transformer> e : transformers.entrySet())
         {
             Type key = e.getKey();
             byte[] bytes = e.getValue().transform();
 
-            // Dump the class in a file
-
-            File outFile = locationOf(outDir, key);
-
-            if (!outFile.getParentFile().isDirectory() && 
-                !outFile.getParentFile().mkdirs())
-                throw new IOException("" + outFile.getParentFile());
-
-			try (DataOutputStream dout = new DataOutputStream(
-					new FileOutputStream(outFile))) {
-				dout.write(bytes);
-				dout.flush();
-			}
-            files.add(outFile);
+            map.put(key, bytes);
         }
-        return files;
-    }
-
-    public static File locationOf(File outDir, Type type) {
-        return new File(outDir, type.getClassName().replace('.', '/') + ".class");
+        return map;
     }
 }

--- a/src/main/java/org/clyze/jphantom/Phantoms.java
+++ b/src/main/java/org/clyze/jphantom/Phantoms.java
@@ -63,15 +63,11 @@ public class Phantoms extends ForwardingSet<Type>
                 !outFile.getParentFile().mkdirs())
                 throw new IOException("" + outFile.getParentFile());
 
-            DataOutputStream dout = new DataOutputStream(
-                new FileOutputStream(outFile));
-
-            try {
-                dout.write(bytes);
-                dout.flush();
-            } finally {
-                dout.close();
-            }
+			try (DataOutputStream dout = new DataOutputStream(
+					new FileOutputStream(outFile))) {
+				dout.write(bytes);
+				dout.flush();
+			}
             files.add(outFile);
         }
         return files;

--- a/src/main/java/org/clyze/jphantom/access/State.java
+++ b/src/main/java/org/clyze/jphantom/access/State.java
@@ -1,6 +1,5 @@
 package org.clyze.jphantom.access;
 
-import java.util.*;
 import org.objectweb.asm.Opcodes;
 
 public class State implements Opcodes

--- a/src/main/java/org/clyze/jphantom/adapters/AccessAdapter.java
+++ b/src/main/java/org/clyze/jphantom/adapters/AccessAdapter.java
@@ -1,6 +1,6 @@
 package org.clyze.jphantom.adapters;
 
-import java.util.*;
+import org.clyze.jphantom.Options;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.ClassVisitor;
 
@@ -9,7 +9,7 @@ public class AccessAdapter extends ClassVisitor implements Opcodes
     private final int access;
 
     public AccessAdapter(ClassVisitor cv, int access) {
-        super(ASM5, cv);
+        super(Options.ASM_VER, cv);
         this.access = access;
     }
 

--- a/src/main/java/org/clyze/jphantom/adapters/ClassPhantomExtractor.java
+++ b/src/main/java/org/clyze/jphantom/adapters/ClassPhantomExtractor.java
@@ -1,5 +1,6 @@
 package org.clyze.jphantom.adapters;
 
+import org.clyze.jphantom.Options;
 import org.clyze.jphantom.Phantoms;
 import org.clyze.jphantom.Transformer;
 import org.clyze.jphantom.ClassMembers;
@@ -8,17 +9,14 @@ import org.clyze.jphantom.methods.MethodSignature;
 import org.clyze.jphantom.access.*;
 import org.clyze.jphantom.hier.*;
 import org.clyze.jphantom.hier.closure.*;
-import org.clyze.jphantom.constraints.*;
 import org.clyze.jphantom.exc.IllegalBytecodeException;
 import org.clyze.jphantom.exc.PhantomLookupException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.util.TraceClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -46,7 +44,7 @@ public class ClassPhantomExtractor extends ClassVisitor implements Opcodes
     }
 
     public ClassPhantomExtractor(ClassVisitor cv, ClassHierarchy hierarchy, ClassMembers members) {
-        this(ASM5, cv, hierarchy, members);
+        this(Options.ASM_VER, cv, hierarchy, members);
     }
 
     public ClassPhantomExtractor(ClassHierarchy hierarchy, ClassMembers members) {

--- a/src/main/java/org/clyze/jphantom/adapters/FieldAdder.java
+++ b/src/main/java/org/clyze/jphantom/adapters/FieldAdder.java
@@ -1,5 +1,6 @@
 package org.clyze.jphantom.adapters;
 
+import org.clyze.jphantom.Options;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
@@ -13,7 +14,7 @@ public class FieldAdder extends ClassVisitor implements Opcodes
 
     public FieldAdder(ClassVisitor cv, int fAcc, String fName, String fDesc)
     {
-        super(ASM5, cv);
+        super(Options.ASM_VER, cv);
         this.fAcc = fAcc;
         this.fName = fName;
         this.fDesc = fDesc;

--- a/src/main/java/org/clyze/jphantom/adapters/InterfaceAdder.java
+++ b/src/main/java/org/clyze/jphantom/adapters/InterfaceAdder.java
@@ -1,6 +1,8 @@
 package org.clyze.jphantom.adapters;
 
 import java.util.*;
+
+import org.clyze.jphantom.Options;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.ClassVisitor;
@@ -11,8 +13,8 @@ public class InterfaceAdder extends ClassVisitor implements Opcodes
 
     public InterfaceAdder(ClassVisitor cv, Set<Type> newInterfaces)
     {
-        super(ASM5, cv);
-        this.ifaces = new HashSet<String>();
+        super(Options.ASM_VER, cv);
+        this.ifaces = new HashSet<>();
 
         for (Type i : newInterfaces)
             ifaces.add(i.getInternalName());
@@ -23,7 +25,7 @@ public class InterfaceAdder extends ClassVisitor implements Opcodes
         String name, String signature, 
         String superName, String[] interfaces)
     {
-        Set<String> allIfaces = new HashSet<String>(ifaces);
+        Set<String> allIfaces = new HashSet<>(ifaces);
         allIfaces.addAll(Arrays.asList(interfaces));
         super.visit(
             version, 

--- a/src/main/java/org/clyze/jphantom/adapters/InterfaceTransformer.java
+++ b/src/main/java/org/clyze/jphantom/adapters/InterfaceTransformer.java
@@ -1,13 +1,13 @@
 package org.clyze.jphantom.adapters;
 
-import java.util.*;
+import org.clyze.jphantom.Options;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.ClassVisitor;
 
 public class InterfaceTransformer extends ClassVisitor implements Opcodes
 {
     public InterfaceTransformer(ClassVisitor cv) {
-        super(ASM5, cv);
+        super(Options.ASM_VER, cv);
     }
 
     @Override

--- a/src/main/java/org/clyze/jphantom/adapters/MethodAdder.java
+++ b/src/main/java/org/clyze/jphantom/adapters/MethodAdder.java
@@ -1,5 +1,6 @@
 package org.clyze.jphantom.adapters;
 
+import org.clyze.jphantom.Options;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.ClassVisitor;
@@ -27,7 +28,7 @@ public class MethodAdder extends ClassVisitor implements Opcodes
     public MethodAdder(
         ClassVisitor cv, int mAcc, String mName, String mDesc, String[] mExc)
     {
-        super(ASM5, cv);
+        super(Options.ASM_VER, cv);
         this.mAcc = mAcc;
         this.mName = mName;
         this.mDesc = mDesc;

--- a/src/main/java/org/clyze/jphantom/adapters/PhantomAdder.java
+++ b/src/main/java/org/clyze/jphantom/adapters/PhantomAdder.java
@@ -21,7 +21,7 @@ public class PhantomAdder extends SignatureVisitor implements Opcodes
 
     public PhantomAdder(ClassHierarchy hierarchy, ClassMembers members, Phantoms phantoms)
     {
-        super(ASM5);
+        super(Options.ASM_VER);
         this.hierarchy = hierarchy;
         this.members = members;
         this.phantoms = phantoms;

--- a/src/main/java/org/clyze/jphantom/adapters/SuperclassAdapter.java
+++ b/src/main/java/org/clyze/jphantom/adapters/SuperclassAdapter.java
@@ -1,5 +1,6 @@
 package org.clyze.jphantom.adapters;
 
+import org.clyze.jphantom.Options;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.ClassVisitor;
@@ -10,7 +11,7 @@ public class SuperclassAdapter extends ClassVisitor implements Opcodes
 
     public SuperclassAdapter(ClassVisitor cv, Type superclass)
     {
-        super(ASM5, cv);
+        super(Options.ASM_VER, cv);
         this.superclass = superclass;
     }
 

--- a/src/main/java/org/clyze/jphantom/constraints/extractors/TypeConstraintExtractor.java
+++ b/src/main/java/org/clyze/jphantom/constraints/extractors/TypeConstraintExtractor.java
@@ -2,12 +2,12 @@ package org.clyze.jphantom.constraints.extractors;
 
 import java.util.*;
 
+import org.clyze.jphantom.Options;
 import org.objectweb.asm.*;
 import org.objectweb.asm.tree.*;
 import org.objectweb.asm.tree.analysis.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.clyze.jphantom.hier.*;
 import org.clyze.jphantom.exc.*;
 import org.clyze.jphantom.dataflow.*;
 import org.clyze.jphantom.conversions.*;
@@ -32,7 +32,7 @@ public class TypeConstraintExtractor extends AbstractExtractor
     public TypeConstraintExtractor(TypeConstraintSolver solver) {
         super(solver);
         this.interpreter = new ExtendedInterpreter(hierarchy);
-        this.analyzer = new Analyzer<CompoundValue>(interpreter);
+        this.analyzer = new Analyzer<>(interpreter);
     }
 
     public final void visit(ClassNode node) throws AnalyzerException {
@@ -106,7 +106,7 @@ public class TypeConstraintExtractor extends AbstractExtractor
         }
 
         public MethodConstraintExtractor(MethodVisitor mv) {
-            this(ASM5, mv);
+            this(Options.ASM_VER, mv);
         }
 
         public MethodConstraintExtractor() {
@@ -564,7 +564,7 @@ public class TypeConstraintExtractor extends AbstractExtractor
         }
     }
 
-    private class UnreachableCodeException extends Exception
+    private static class UnreachableCodeException extends Exception
     {
         protected static final long serialVersionUID = 893453456345L;
     }

--- a/src/main/java/org/clyze/jphantom/constraints/solvers/AbstractSolver.java
+++ b/src/main/java/org/clyze/jphantom/constraints/solvers/AbstractSolver.java
@@ -1,7 +1,6 @@
 package org.clyze.jphantom.constraints.solvers;
 
 import org.clyze.jphantom.util.Factory;
-import java.util.*;
 import org.jgrapht.*;
 import org.jgrapht.graph.*;
 
@@ -17,14 +16,14 @@ public abstract class AbstractSolver<V,E,S> implements Solver<V,E,S>
     ////////////// Constructors //////////////
 
     public AbstractSolver(EdgeFactory<V,E> factory, Factory<S> solutionFactory) {
-        this(new SimpleDirectedGraph<V,E>(factory), solutionFactory);
+        this(new SimpleDirectedGraph<>(factory), solutionFactory);
     }
 
     public AbstractSolver(DirectedGraph<V,E> graph, Factory<S> solutionFactory) {
         this.solutionFactory = solutionFactory;
         this.factory = graph.getEdgeFactory();
         this._graph = graph;
-        this.unmodifiableGraph = new UnmodifiableDirectedGraph<V,E>(graph);
+        this.unmodifiableGraph = new UnmodifiableDirectedGraph<>(graph);
     }
 
     //////////////// Methods ////////////////
@@ -49,7 +48,7 @@ public abstract class AbstractSolver<V,E,S> implements Solver<V,E,S>
     {
         if (solved) { return this; }
 
-        DirectedGraph<V,E> backup = new SimpleDirectedGraph<V,E>(factory);
+        DirectedGraph<V,E> backup = new SimpleDirectedGraph<>(factory);
         Graphs.addGraph(backup, _graph);
         solution = solutionFactory.create();
         solve(backup);

--- a/src/main/java/org/clyze/jphantom/constraints/solvers/BasicSolver.java
+++ b/src/main/java/org/clyze/jphantom/constraints/solvers/BasicSolver.java
@@ -10,8 +10,6 @@ import org.clyze.jphantom.constraints.*;
 import org.jgrapht.*;
 import org.objectweb.asm.Type;
 
-import static org.jgrapht.Graphs.*;
-
 public class BasicSolver extends InterfaceSolver<Type,SubtypeConstraint,ClassHierarchy>
     implements Types, TypeConstraintSolver
 {
@@ -456,7 +454,7 @@ public class BasicSolver extends InterfaceSolver<Type,SubtypeConstraint,ClassHie
                         throw new UnsatisfiableStateException();
                 } catch (IncompleteSupertypesException ign) {
                     // Add constraint since it can be satisfied eventually
-                    constraints.add(new Pair<Type,Type>(source, target));
+                    constraints.add(new Pair<>(source, target));
                 }
             }
 

--- a/src/main/java/org/clyze/jphantom/constraints/solvers/ForwardingSolver.java
+++ b/src/main/java/org/clyze/jphantom/constraints/solvers/ForwardingSolver.java
@@ -1,7 +1,7 @@
 package org.clyze.jphantom.constraints.solvers;
 
 import java.util.*;
-import org.clyze.jphantom.exc.*;
+
 import org.clyze.jphantom.hier.*;
 import org.clyze.jphantom.constraints.*;
 import org.jgrapht.*;

--- a/src/main/java/org/clyze/jphantom/constraints/solvers/InterfaceSolver.java
+++ b/src/main/java/org/clyze/jphantom/constraints/solvers/InterfaceSolver.java
@@ -34,14 +34,14 @@ public abstract class InterfaceSolver<V,E,S> extends AbstractSolver<V,E,S>
         public Builder(V root, Factory<S> factory, DirectedGraph<V,E> graph)
         {
             this.root = root;
-            this.strategy = new MinClassesStrategy<V,E>(root);
+            this.strategy = new MinClassesStrategy<>(root);
             this.factory = factory;
             this.graph = graph;
         }
 
         public Builder(V root, Factory<S> factory, EdgeFactory<V,E> efactory)
         {
-            this(root, factory, new SimpleDirectedGraph<V,E>(efactory));
+            this(root, factory, new SimpleDirectedGraph<>(efactory));
         }
 
         public Builder<V,E,S> minimize(boolean min) {
@@ -99,8 +99,8 @@ public abstract class InterfaceSolver<V,E,S> extends AbstractSolver<V,E,S>
         classes = strategy.classSubsetOf(graph);
 
         // Interface Graph
-        DirectedGraph<V,E> igraph = 
-            new SimpleDirectedGraph<V,E>(graph.getEdgeFactory());
+        DirectedGraph<V,E> igraph =
+                new SimpleDirectedGraph<>(graph.getEdgeFactory());
                 
         // Fill interface graph
         for (E e : new HashSet<>(graph.edgeSet()))
@@ -152,14 +152,14 @@ public abstract class InterfaceSolver<V,E,S> extends AbstractSolver<V,E,S>
     protected void solveClassGraph(DirectedGraph<V,E> graph) 
         throws UnsatisfiableStateException
     {
-        classSolver = new SingleInheritanceSolver<V,E>(graph, root);
+        classSolver = new SingleInheritanceSolver<>(graph, root);
         classSolver.solve();
     }
 
     protected void solveInterfaceGraph(DirectedGraph<V,E> graph)
         throws UnsatisfiableStateException
     {
-        ifaceSolver = new MultipleInheritanceSolver<V,E>(graph, minimize);
+        ifaceSolver = new MultipleInheritanceSolver<>(graph, minimize);
         ifaceSolver.solve();
     }
 

--- a/src/main/java/org/clyze/jphantom/constraints/solvers/LayeringSolver.java
+++ b/src/main/java/org/clyze/jphantom/constraints/solvers/LayeringSolver.java
@@ -40,12 +40,12 @@ public abstract class LayeringSolver<V,E> extends MultipleInheritanceSolver<V,E>
         Set<E> specialEdges = new HashSet<>();
         Set<V> next = graph.vertexSet();
 
-        List<Set<V>> strata = new LinkedList<>(Arrays.asList(next));
+        List<Set<V>> strata = new LinkedList<>(Collections.singletonList(next));
 
         while(true)
         {
             Set<V> prev = next;
-            next = new HashSet<V>();
+            next = new HashSet<>();
 
             strata.add(next);
             

--- a/src/main/java/org/clyze/jphantom/constraints/solvers/MinClassesStrategy.java
+++ b/src/main/java/org/clyze/jphantom/constraints/solvers/MinClassesStrategy.java
@@ -18,7 +18,7 @@ public class MinClassesStrategy<V,E> implements InterfaceSolver.Strategy<V,E>
     protected Colored<V> getColored(V vertex)
     {
         if (!colored.containsKey(vertex))
-            colored.put(vertex, new Colored<V>(vertex));
+            colored.put(vertex, new Colored<>(vertex));
 
         return colored.get(vertex);
     }

--- a/src/main/java/org/clyze/jphantom/constraints/solvers/MultipleInheritanceSolver.java
+++ b/src/main/java/org/clyze/jphantom/constraints/solvers/MultipleInheritanceSolver.java
@@ -50,13 +50,13 @@ public class MultipleInheritanceSolver<V,E> extends AbstractSolver<V,E,Map<V,Lis
     protected void solve(DirectedGraph<V,E> graph) throws UnsatisfiableStateException
     {
         // Check for cycles in the interface graph
-        if (new CycleDetector<V,E>(graph).detectCycles())
+        if (new CycleDetector<>(graph).detectCycles())
             throw new GraphCycleException();
 
         // Remove redundant edges
         if (minimize) {
             // Compute transitive closure
-            SimpleDirectedGraph<V,E> closure = new SimpleDirectedGraph<V,E>(factory);
+            SimpleDirectedGraph<V,E> closure = new SimpleDirectedGraph<>(factory);
 
             addGraph(closure, graph);
             TransitiveClosure.INSTANCE.closeSimpleDirectedGraph(closure);

--- a/src/main/java/org/clyze/jphantom/constraints/solvers/SingleInheritanceSolver.java
+++ b/src/main/java/org/clyze/jphantom/constraints/solvers/SingleInheritanceSolver.java
@@ -40,11 +40,11 @@ public class SingleInheritanceSolver<V,E> extends AbstractSolver<V,E,Map<V,V>>
     
     private DirectedGraph<V,E> getComponent(DirectedGraph<V,E> graph, V node)
     {
-        UndirectedGraph<V,E> undirectedView = new AsUndirectedGraph<V,E>(graph);
+        UndirectedGraph<V,E> undirectedView = new AsUndirectedGraph<>(graph);
 
-        Set<V> nodes = new ConnectivityInspector<V,E>(undirectedView).connectedSetOf(node);
-        DirectedGraph<V,E> subgraph = new DirectedSubgraph<V,E>(graph, nodes, null);
-        DirectedGraph<V,E> result = new SimpleDirectedGraph<V,E>(graph.getEdgeFactory());
+        Set<V> nodes = new ConnectivityInspector<>(undirectedView).connectedSetOf(node);
+        DirectedGraph<V,E> subgraph = new DirectedSubgraph<>(graph, nodes, null);
+        DirectedGraph<V,E> result = new SimpleDirectedGraph<>(graph.getEdgeFactory());
         Graphs.addGraph(result, subgraph);
 
         return result;

--- a/src/main/java/org/clyze/jphantom/constraints/solvers/Solver.java
+++ b/src/main/java/org/clyze/jphantom/constraints/solvers/Solver.java
@@ -1,7 +1,6 @@
 package org.clyze.jphantom.constraints.solvers;
 
 import org.jgrapht.*;
-import java.util.*;
 
 public interface Solver<V,E,S> {
 

--- a/src/main/java/org/clyze/jphantom/constraints/solvers/TypeConstraintSolver.java
+++ b/src/main/java/org/clyze/jphantom/constraints/solvers/TypeConstraintSolver.java
@@ -1,7 +1,7 @@
 package org.clyze.jphantom.constraints.solvers;
 
 import java.util.*;
-import org.clyze.jphantom.exc.*;
+
 import org.clyze.jphantom.hier.*;
 import org.clyze.jphantom.constraints.*;
 import org.objectweb.asm.Type;

--- a/src/main/java/org/clyze/jphantom/conversions/Conversions.java
+++ b/src/main/java/org/clyze/jphantom/conversions/Conversions.java
@@ -64,7 +64,7 @@ public class Conversions implements Types {
     }
 
     static {
-        Set<Type> tmp = new HashSet<>(Arrays.asList(Type.DOUBLE_TYPE));
+        Set<Type> tmp = new HashSet<>(Collections.singletonList(Type.DOUBLE_TYPE));
 
         Type[] types = {
             Type.FLOAT_TYPE, Type.LONG_TYPE, Type.INT_TYPE, 
@@ -96,7 +96,7 @@ public class Conversions implements Types {
 
     public static Conversion getAssignmentConversion(Type from, Type to)
     {
-        Pair<Type,Type> pair = new Pair<Type,Type>(from, to);
+        Pair<Type,Type> pair = new Pair<>(from, to);
 
         if (!cache.containsKey(pair))
             cache.put(pair, newAssignmentConversion(pair));

--- a/src/main/java/org/clyze/jphantom/dataflow/ExtendedInterpreter.java
+++ b/src/main/java/org/clyze/jphantom/dataflow/ExtendedInterpreter.java
@@ -1,6 +1,8 @@
 package org.clyze.jphantom.dataflow;
 
 import java.util.*;
+
+import org.clyze.jphantom.Options;
 import org.clyze.jphantom.hier.*;
 
 import org.objectweb.asm.Opcodes;
@@ -13,7 +15,7 @@ public class ExtendedInterpreter extends Interpreter<CompoundValue> implements O
     private TypeInterpreter i; // delegator
 
     public ExtendedInterpreter(ClassHierarchy hier) {
-        this(ASM5, hier);
+        this(Options.ASM_VER, hier);
     }
 
     public ExtendedInterpreter(int api, ClassHierarchy hier) {

--- a/src/main/java/org/clyze/jphantom/dataflow/TypeInterpreter.java
+++ b/src/main/java/org/clyze/jphantom/dataflow/TypeInterpreter.java
@@ -2,7 +2,6 @@ package org.clyze.jphantom.dataflow;
 
 import java.util.*;
 import org.clyze.jphantom.*;
-import org.clyze.jphantom.exc.*;
 import org.clyze.jphantom.hier.*;
 import org.clyze.jphantom.hier.closure.*;
 import org.objectweb.asm.tree.analysis.*;
@@ -13,16 +12,16 @@ import org.objectweb.asm.Type;
 public class TypeInterpreter extends BasicInterpreter implements Opcodes, Types
 {
     private static final Map<Type,BasicValue> values = new HashMap<>();
-    protected static final BasicValue NULL_VALUE = new BasicValue(NULL_TYPE);
+    protected static final BasicValue NULL_VALUE = new BasicValue(BasicInterpreter.NULL_TYPE);
 
     static {
-        values.put(NULL_TYPE, NULL_VALUE);
+        values.put(BasicInterpreter.NULL_TYPE, NULL_VALUE);
     }
 
     private ClassHierarchy.Snapshot closure;
 
     public TypeInterpreter(ClassHierarchy hier) {
-        this(ASM5, hier);
+        this(Options.ASM_VER, hier);
     }
 
     public TypeInterpreter(int api, ClassHierarchy hier) {

--- a/src/main/java/org/clyze/jphantom/fields/FieldSignature.java
+++ b/src/main/java/org/clyze/jphantom/fields/FieldSignature.java
@@ -1,7 +1,6 @@
 package org.clyze.jphantom.fields;
 
 import org.clyze.jphantom.Signature;
-import java.util.*;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.FieldNode;
 

--- a/src/main/java/org/clyze/jphantom/hier/ClassHierarchies.java
+++ b/src/main/java/org/clyze/jphantom/hier/ClassHierarchies.java
@@ -69,29 +69,29 @@ public class ClassHierarchies implements Opcodes, Types
                 if(!entry.getName().endsWith(".class"))
                     continue;
 
-				try (InputStream stream = file.getInputStream(entry)) {
-					ClassReader reader = new ClassReader(stream);
-					String ifaceNames[] = reader.getInterfaces();
+                try (InputStream stream = file.getInputStream(entry)) {
+                    ClassReader reader = new ClassReader(stream);
+                    String ifaceNames[] = reader.getInterfaces();
 
-					// Compute Types
+                    // Compute Types
 
-					Type clazz = Type.getObjectType(reader.getClassName());
-					Type superclass = Type.getObjectType(reader.getSuperName());
-					Type ifaces[] = new Type[ifaceNames.length];
+                    Type clazz = Type.getObjectType(reader.getClassName());
+                    Type superclass = Type.getObjectType(reader.getSuperName());
+                    Type ifaces[] = new Type[ifaceNames.length];
 
-					for (int i = 0; i < ifaces.length; i++)
-						ifaces[i] = Type.getObjectType(ifaceNames[i]);
+                    for (int i = 0; i < ifaces.length; i++)
+                        ifaces[i] = Type.getObjectType(ifaceNames[i]);
 
-					// Add type to hierarchy
-					boolean isInterface = (reader.getAccess() & ACC_INTERFACE) != 0;
+                    // Add type to hierarchy
+                    boolean isInterface = (reader.getAccess() & ACC_INTERFACE) != 0;
 
-					if (isInterface) {
-						hierarchy.addInterface(clazz, ifaces);
-						assert superclass.equals(OBJECT);
-					} else {
-						hierarchy.addClass(clazz, superclass, ifaces);
-					}
-				}
+                    if (isInterface) {
+                        hierarchy.addInterface(clazz, ifaces);
+                        assert superclass.equals(OBJECT);
+                    } else {
+                        hierarchy.addClass(clazz, superclass, ifaces);
+                    }
+                }
             }
             return hierarchy;
         } finally {

--- a/src/main/java/org/clyze/jphantom/hier/UnmodifiableClassHierarchy.java
+++ b/src/main/java/org/clyze/jphantom/hier/UnmodifiableClassHierarchy.java
@@ -1,6 +1,5 @@
 package org.clyze.jphantom.hier;
 
-import java.util.*;
 import org.objectweb.asm.Type;
 
 public class UnmodifiableClassHierarchy extends ForwardingClassHierarchy

--- a/src/main/java/org/clyze/jphantom/hier/closure/AbstractSnapshot.java
+++ b/src/main/java/org/clyze/jphantom/hier/closure/AbstractSnapshot.java
@@ -1,6 +1,5 @@
 package org.clyze.jphantom.hier.closure;
 
-import java.util.*;
 import org.clyze.jphantom.hier.*;
 import org.objectweb.asm.Type;
 

--- a/src/main/java/org/clyze/jphantom/hier/closure/CopyingSnapshot.java
+++ b/src/main/java/org/clyze/jphantom/hier/closure/CopyingSnapshot.java
@@ -14,8 +14,8 @@ import static org.jgrapht.Graphs.*;
 public class CopyingSnapshot extends PseudoSnapshot
 {
     private final DirectedGraph<Node,Edge> graph;
-    private final SimpleDirectedGraph<Node,Edge> closedGraph = 
-        new SimpleDirectedGraph<Node,Edge>(Edge.factory);
+    private final SimpleDirectedGraph<Node,Edge> closedGraph =
+            new SimpleDirectedGraph<>(Edge.factory);
 
     public CopyingSnapshot(ClassHierarchy other)
     {

--- a/src/main/java/org/clyze/jphantom/hier/closure/PseudoSnapshot.java
+++ b/src/main/java/org/clyze/jphantom/hier/closure/PseudoSnapshot.java
@@ -63,7 +63,7 @@ public class PseudoSnapshot extends AbstractSnapshot
     {
         checkedContainedObject(obj);
         Set<Type> supertypes = new HashSet<>();
-        Queue<Type> queue = new LinkedList<Type>();
+        Queue<Type> queue = new LinkedList<>();
         boolean incomplete = false;
         
         do {
@@ -79,8 +79,7 @@ public class PseudoSnapshot extends AbstractSnapshot
                     continue;
                 }
 
-                for (Type i : getInterfaces(t))
-                    queue.add(i);
+                queue.addAll(getInterfaces(t));
             }
             if (!contains(obj))
                 break;

--- a/src/main/java/org/clyze/jphantom/hier/graph/GraphConverter.java
+++ b/src/main/java/org/clyze/jphantom/hier/graph/GraphConverter.java
@@ -17,8 +17,8 @@ public class GraphConverter implements Types
 
     public DirectedGraph<Node,Edge> convert()
     {
-        DirectedGraph<Node,Edge> graph = 
-            new SimpleDirectedGraph<Node,Edge>(Edge.factory);
+        DirectedGraph<Node,Edge> graph =
+                new SimpleDirectedGraph<>(Edge.factory);
 
         // Add vertices
 
@@ -47,7 +47,7 @@ public class GraphConverter implements Types
 
         // Check for cycles 
 
-        if (new CycleDetector<Node,Edge>(graph).detectCycles())
+        if (new CycleDetector<>(graph).detectCycles())
             throw new CyclicHierarchyException(graph.toString());
 
         return graph;

--- a/src/main/java/org/clyze/jphantom/jar/JarExtender.java
+++ b/src/main/java/org/clyze/jphantom/jar/JarExtender.java
@@ -79,7 +79,7 @@ public class JarExtender
                 logger.info("Adding entry: " + file);
 
                 // Create a jar entry and add it to the temp jar.
-                JarEntry entry = new JarEntry(file.toString());
+                JarEntry entry = new JarEntry(file.toString().replace("\\", "/"));
                 jar.putNextEntry(entry);
 
                 // Read the file and write it to the jar.

--- a/src/main/java/org/clyze/jphantom/jar/JarExtender.java
+++ b/src/main/java/org/clyze/jphantom/jar/JarExtender.java
@@ -34,36 +34,29 @@ public class JarExtender
 
     public void extend() throws IOException
     {
-        JarFile injar = new JarFile(in.toFile());
 
-        try {
+        try (JarFile injar = new JarFile(in.toFile())) {
             // Manifest jarManifest = injar.getManifest();
-            JarOutputStream outjar = new JarOutputStream(
-                new FileOutputStream(out.toFile()));
 
-            try {
+            try (JarOutputStream outjar = new JarOutputStream(
+                    new FileOutputStream(out.toFile()))) {
                 logger.info("Copying old entries...");
 
                 // Copy the old jar
-                for (JarEntry entry : Collections.list(injar.entries()))
-                {
+                for (JarEntry entry : Collections.list(injar.entries())) {
                     // Get an input stream for the entry.
                     InputStream entryStream = injar.getInputStream(entry);
 
                     // Read the entry and write it to the temp jar.
                     outjar.putNextEntry(entry);
-                    
+
                     while ((bytesRead = entryStream.read(buffer)) != -1)
                         outjar.write(buffer, 0, bytesRead);
                 }
 
                 // Add the complement files
                 Files.walkFileTree(dir, new JarEntryCopyingVisitor(outjar));
-            } finally {
-                outjar.close();
             }
-        } finally {
-            injar.close();
         }
     }
 
@@ -79,23 +72,19 @@ public class JarExtender
         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
             throws IOException
         {
-            InputStream stream = new FileInputStream(file.toFile());
-            file = file.toAbsolutePath();
 
-            try
-            {
+            try (InputStream stream = new FileInputStream(file.toFile())) {
+                file = file.toAbsolutePath();
                 file = dir.toAbsolutePath().relativize(file);
                 logger.info("Adding entry: " + file);
 
                 // Create a jar entry and add it to the temp jar.
                 JarEntry entry = new JarEntry(file.toString());
                 jar.putNextEntry(entry);
-                            
+
                 // Read the file and write it to the jar.
                 while ((bytesRead = stream.read(buffer)) != -1)
                     jar.write(buffer, 0, bytesRead);
-            } finally {
-                stream.close();
             }
 
             return FileVisitResult.CONTINUE;

--- a/src/main/java/org/clyze/jphantom/methods/MethodLookupTable.java
+++ b/src/main/java/org/clyze/jphantom/methods/MethodLookupTable.java
@@ -1,11 +1,12 @@
 package org.clyze.jphantom.methods;
 
 import java.util.*;
+
+import org.clyze.jphantom.Options;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
-import org.clyze.jphantom.access.*;
 import org.clyze.jphantom.exc.IllegalBytecodeException;
 
 public class MethodLookupTable extends HashMap<Type, Set<MethodSignature>> {
@@ -53,11 +54,11 @@ public class MethodLookupTable extends HashMap<Type, Set<MethodSignature>> {
         }
 
         public CachingAdapter(ClassVisitor cv) {
-            this(ASM5, cv);
+            this(Options.ASM_VER, cv);
         }
 
         public CachingAdapter() {
-            this(ASM5);
+            this(Options.ASM_VER);
         }
 
         @Override

--- a/src/main/java/org/clyze/jphantom/util/GraphUtils.java
+++ b/src/main/java/org/clyze/jphantom/util/GraphUtils.java
@@ -28,7 +28,7 @@ public class GraphUtils
                 throw new IllegalArgumentException();
 
         if (edgeSubset == null) {
-            Set<E> tmp = new HashSet<E>();
+            Set<E> tmp = new HashSet<>();
 
             for (V vertex : vertexSubset)
                 tmp.addAll(baseGraph.edgesOf(vertex));

--- a/src/main/java/org/clyze/jphantom/util/MapFactory.java
+++ b/src/main/java/org/clyze/jphantom/util/MapFactory.java
@@ -8,6 +8,6 @@ public class MapFactory<K,V> implements Factory<Map<K,V>>
 
     @Override
     public Map<K,V> create() {
-        return new HashMap<K,V>();
+        return new HashMap<>();
     }
 }

--- a/src/main/java/org/clyze/jphantom/util/Pair.java
+++ b/src/main/java/org/clyze/jphantom/util/Pair.java
@@ -2,44 +2,44 @@ package org.clyze.jphantom.util;
 
 public class Pair <A, B> {
 
-	public final A fst;
-	public final B snd;
+    public final A fst;
+    public final B snd;
 
-	public Pair(A fst, B snd) {
-		this.fst = fst;
-		this.snd = snd;
-	}
+    public Pair(A fst, B snd) {
+        this.fst = fst;
+        this.snd = snd;
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((fst == null) ? 0 : fst.hashCode());
-		result = prime * result + ((snd == null) ? 0 : snd.hashCode());
-		return result;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((fst == null) ? 0 : fst.hashCode());
+        result = prime * result + ((snd == null) ? 0 : snd.hashCode());
+        return result;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Pair<?, ?> other = (Pair<?, ?>) obj;
-		if (fst == null) {
-			if (other.fst != null)
-				return false;
-		} else if (!fst.equals(other.fst))
-			return false;
-		if (snd == null) {
-			if (other.snd != null)
-				return false;
-		} else if (!snd.equals(other.snd))
-			return false;
-		return true;
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Pair<?, ?> other = (Pair<?, ?>) obj;
+        if (fst == null) {
+            if (other.fst != null)
+                return false;
+        } else if (!fst.equals(other.fst))
+            return false;
+        if (snd == null) {
+            if (other.snd != null)
+                return false;
+        } else if (!snd.equals(other.snd))
+            return false;
+        return true;
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
## Dependencies updated

| Name | Old version | Updated version |
|:----:|:--------------------:|:----------------------------------:|
| ASM   |   5.0.3   |   8.0.1       |
| Guava |   18.0   |   29.0-jre   |
| args4j |   2.0.23   |   2.33   |
| logback |   1.0.10   |   1.2.3   |
| slf4j |   1.7.3   |   1.7.30   |
| commons-lang3 | 3.1 | 3.11 |
| annotations | 2.0.1 | 3.0.1 |

## Maven plugins updated

| Name | Old version | Updated version |
|:----:|:--------------------:|:----------------------------------:|
| maven-site-plugin |   3.1   |   3.9.0       |
| nexus-staging-maven-plugin | 1.6.3 | 1.6.8 | 
| maven-source-plugin | 3.0.0 | 3.2.1 | 
| maven-javadoc-plugin | 2.10.3 | 3.2.0 |
| maven-jar-plugin | 3.0.0 | 3.2.0 |
| maven-assembly-plugin | ??? | 3.3.0 | 
| maven-compiler-plugin | 3.5.1 | 3.8.1 |
| findbugs-maven-plugin | 2.5 | 3.0.5 | 

## Other changes

* Updated JPhantom version from `1.2.0` to `1.3.0`
* Extracted logic from driver to allow easy usage of JPhantom as a library with the newly added `JPhantom` class
* Point all ASM version usage to a constant
* Changed project source level from `1.7` to `1.8`
    * Replaced `try { Closable ....` with `try (Closable ...) {`
    * Replaced generics with `<>`
* Removed unused imports
* Added maven version plugin _(used to query plugin/dependency updates)_
