### PR TITLE
Force Java to recalculate compressed size, fixing a bug with certain types of otherwise valid zip/jar files

### DIFF
--- a/src/main/java/org/clyze/jphantom/jar/JarExtender.java
+++ b/src/main/java/org/clyze/jphantom/jar/JarExtender.java
@@ -46,6 +46,7 @@ public class JarExtender
                 for (JarEntry entry : Collections.list(injar.entries())) {
                     // Get an input stream for the entry.
                     InputStream entryStream = injar.getInputStream(entry);
+                    entry.setCompressedSize(-1); // force java to recalculate compressed size, preventing an error 
 
                     // Read the entry and write it to the temp jar.
                     outjar.putNextEntry(entry);

--- a/src/main/java/org/clyze/jphantom/jar/JarExtender.java
+++ b/src/main/java/org/clyze/jphantom/jar/JarExtender.java
@@ -80,6 +80,7 @@ public class JarExtender
 
                 // Create a jar entry and add it to the temp jar.
                 JarEntry entry = new JarEntry(file.toString().replace("\\", "/"));
+                entry.setCompressedSize(-1); // force java to recalculate compressed size, preventing an error 
                 jar.putNextEntry(entry);
 
                 // Read the file and write it to the jar.


### PR DESCRIPTION
Example zip: 
[testout-obf.zip](https://github.com/gbalats/jphantom/files/9378560/testout-obf.zip)
